### PR TITLE
Fixed flaky test

### DIFF
--- a/src/test/java/com/dgf/shopcart/rest/handler/BaseHandlerTest.java
+++ b/src/test/java/com/dgf/shopcart/rest/handler/BaseHandlerTest.java
@@ -4,6 +4,7 @@ import com.dgf.shopcart.TestConfig;
 import com.dgf.shopcart.model.Item;
 import com.dgf.shopcart.rest.handler.req.CartItemAddRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
@@ -61,7 +62,16 @@ public abstract class BaseHandlerTest {
                 .consumeNextWith(System.out::println)
                 .expectComplete().verify();
         assertThat(mockResponse.getHeaders().getContentType()).isEqualTo(APPLICATION_JSON);
-        assertThat(mockResponse.getBodyAsString().block()).isEqualTo(expectedBody);
+        String bodyAsString = mockResponse.getBodyAsString().block();
+        JsonNode expectedJson = null;
+        JsonNode bodyAsStringJson = null;
+        try {
+            expectedJson = mapper.readTree(expectedBody);
+            bodyAsStringJson = mapper.readTree(bodyAsString);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        assertThat(bodyAsStringJson).isEqualTo(expectedJson);
     }
 
 


### PR DESCRIPTION
### Flakiness
**Nondex** was used to check and locate the flakiness in the test. The test can be reproduced using the following command:
First add 
```
buildscript {
    repositories {
      maven {
        url = uri('https://plugins.gradle.org/m2/')
      }
    }
    dependencies {
      classpath('edu.illinois:plugin:2.1.1')
    }
}
```
to the beginning of `build.gradle` and
```
apply plugin: 'edu.illinois.nondex'
```
at the end of `build.gradle` .
Then replace 
```
test {
  useJUnitPlatform()
}
```
with 
```
tasks.withType(Test) {
  useJUnitPlatform()
}
```
in `build.gradle`.
Then run the following command:
```shell
./gradlew build -x test
./gradlew --info test --tests com.dgf.shopcart.rest.handler.CartHandlerTest.add 
./gradlew --info nondexTest --tests=com.dgf.shopcart.rest.handler.CartHandlerTest.add 
``` 

### Issue
The root issue is that both `mockResponse.getBodyAsString` and `mapper.writeValueAsString` use maps to convert json data into strings. In this case both strings are checked if match to determine the mockResponse has the correct content. However, because map does not guarantee the order of elements returned, the two strings could have the same content but in different order, thus the flakiness. 

## Fix
This flaky test has been fixed through leveraging the Jackson library, which incorporates the JsonNode and ObjectMapper classes. These components are employed for parsing two JSON strings into tree models, which are subsequently compared node by node when assertion is called. 